### PR TITLE
Issue 373

### DIFF
--- a/examples/corb2-project/build.gradle
+++ b/examples/corb2-project/build.gradle
@@ -18,12 +18,12 @@ buildscript {
   }
   dependencies {
     //Needed for CorbTask to dynamicaly generate properties from CORB Options class
-    classpath 'com.marklogic:marklogic-corb:2.3.2'
+    classpath 'com.marklogic:marklogic-corb:2.4.1'
   }
 }
 
 plugins {
-    id "com.marklogic.ml-gradle" version "3.6.0"
+    id "com.marklogic.ml-gradle" version "3.9.0"
 }
 
 repositories {
@@ -42,7 +42,7 @@ configurations {
 
 dependencies {
     // required to run CoRB2
-    corb 'com.marklogic:marklogic-corb:2.3.2'
+    corb 'com.marklogic:marklogic-corb:2.4.1'
     // optional
     //corb 'org.jasypt:jasypt:1.9.2' // would be necessary to leverage JasyptDecrypter
 }
@@ -97,7 +97,7 @@ task corb(type: com.marklogic.gradle.task.CorbTask) {
  * the transform.xqy module to perform any action that you would like - this is just to show how to invoke corb from Gradle.
  */
 task corbAdhoc(type: com.marklogic.gradle.task.CorbTask) {
-    xccConnectionUri = contentXccUrl
+		xccConnectionUri = contentXccUrl
     urisModule = "src/main/ml-modules/ext/corb2-project/corb/uris.xqy|ADHOC"
     processModule = "src/main/ml-modules/ext/corb2-project/corb/transform.xqy|ADHOC"
 }

--- a/examples/local-testing-project/README.md
+++ b/examples/local-testing-project/README.md
@@ -4,11 +4,10 @@ that you've published to your local Maven repository.
 To publish an instance of ml-gradle locally, just do the following:
 
 1. From the ml-gradle root directory, run "publish -Pversion=DEV publishToMavenLocal" (you can pick any version name that you want)
-1. Verify manually that the library was published to ~/.m2/com/marklogic/ml-gradle
+1. Verify manually that the library was published to ~/.m2/repository/com/marklogic/ml-gradle
 
 You should then be able to run "gradle tasks" on this project, and that will use your
 locally published copy of ml-gradle. Again, feel free to change the version name to whatever
 you want, there's no requirement to use "DEV". 
 
-Note that the "src" directory is gitignore'd in this project so that you can add any artifacts you want. 
- 
+Note that the "src" directory is gitignore'd in this project so that you can add any artifacts you want.

--- a/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/CorbTask.groovy
@@ -153,11 +153,11 @@ XQUERY-MODULE".tokenize(',')
     this.metaClass.getProperties().collectEntries {
       String corbOptionKey = CORB_PROPERTY_PREFIX + it.name.capitalize()
       //evaluate whether a value is set and the name matches the corbOptions key pattern
-      if (this[it.name] && corbOptions[corbOptionKey]) {
-        [(corbOptions[corbOptionKey]): this[it.name] ]
-      } else {
-        [:]
-      }
+	  if (corbOptions[corbOptionKey] && this[it.name]) {
+	    [(corbOptions[corbOptionKey]): this[it.name] ]
+	  } else {
+	    [:]
+	  }
     }
   }
 


### PR DESCRIPTION
Resolves issue 373 by ensuring that we only attempt to access the metaClass property if it's name is a key in the corbOption map. In newer versions of Gradle, properties such as `validators` throw exceptions when attempting to access them.

Also:
- updated versions of CORB2 and ml-gradle in the examples/corb2-project
- corrected the path for local maven repo in the examples/local-testing/README.md 