### PR TITLE
#430 Changed directory structure of unit test report output

### DIFF
--- a/src/main/groovy/com/marklogic/gradle/task/test/UnitTestTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/test/UnitTestTask.groovy
@@ -78,24 +78,33 @@ class UnitTestTask extends MarkLogicTask {
 					println "Unable to delete test results directory: " + resultsPath
 				}
 			}
-			resultsDir.mkdirs()
+			
+			String resultsPathPassed = resultsPath + "/passed"
+			String resultsPathFailed = resultsPath + "/failed"
+			File resultsDirPassed = new File(resultsPathPassed)
+			File resultsDirFailed = new File(resultsPathFailed)
+			resultsDirPassed.mkdirs()
+			resultsDirFailed.mkdirs()
 
 			int fileCount = 0;
 			boolean testsFailed = false
 			for (JUnitTestSuite suite : suites) {
-				if (suite.hasTestFailures()) {
-					testsFailed = true
-				}
 				String xml = suite.getXml()
 				String filename = "TEST-" + suite.getName() + ".xml"
-				org.springframework.util.FileCopyUtils.copy(xml.getBytes(), new File(resultsDir, filename))
+				if (suite.hasTestFailures()) {
+					testsFailed = true
+					org.springframework.util.FileCopyUtils.copy(xml.getBytes(), new File(resultsDirFailed, filename))
+				}
+				else {
+					org.springframework.util.FileCopyUtils.copy(xml.getBytes(), new File(resultsDirPassed, filename))
+				}
 				fileCount++;
 			}
 
 			println "\n" + fileCount + " test result files were written to: " + resultsPath
 
 			if (testsFailed) {
-				throw new GradleException("There were failing tests. See the test results at: " + resultsPath)
+				throw new GradleException("There were failing tests. See the test results at: " + resultsPathFailed)
 			}
 
 		} finally {


### PR DESCRIPTION
Changed the directory structure of unit test report output when running the mlUnitTest gradle task so that all failed tests are written to a "failed" directory within build/test-results/marklogic-unit-test, while all successful tests are written to a "passed" directory in the same location.

This should help solve the issue raised in https://github.com/marklogic-community/marklogic-unit-test/issues/46 where it was pointed out that it wasn't possible to work out which tests have failed without looking through all the test reports.

I've also created a related pull request (https://github.com/marklogic-community/marklogic-unit-test/pull/61) that deals with the other issue outlined in the above ticket that it's hard to read the test failure stack output.