### PR TITLE
Test Results for Nested Test Suites

### DIFF
--- a/src/main/groovy/com/marklogic/gradle/task/test/UnitTestTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/test/UnitTestTask.groovy
@@ -90,7 +90,7 @@ class UnitTestTask extends MarkLogicTask {
 					testsFailed = true
 				}
 				String xml = suite.getXml()
-				String filename = "TEST-" + suite.getName() + ".xml"
+				String filename = "TEST-" + suite.getName().replaceAll("(/|\\\\)", "_") + ".xml"
 				org.springframework.util.FileCopyUtils.copy(xml.getBytes(), new File(resultsDir, filename))
 				fileCount++;
 			}

--- a/src/main/groovy/com/marklogic/gradle/task/test/UnitTestTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/test/UnitTestTask.groovy
@@ -90,7 +90,7 @@ class UnitTestTask extends MarkLogicTask {
 					testsFailed = true
 				}
 				String xml = suite.getXml()
-				String filename = "TEST-" + suite.getName().replaceAll("(/|\\\\)", "_") + ".xml"
+				String filename = "TEST-" + escapeFilename(suite.getName()) + ".xml"
 				org.springframework.util.FileCopyUtils.copy(xml.getBytes(), new File(resultsDir, filename))
 				fileCount++;
 			}
@@ -104,5 +104,9 @@ class UnitTestTask extends MarkLogicTask {
 		} finally {
 			client.release()
 		}
+	}
+
+	static String escapeFilename(String filename) {
+		return filename.replaceAll("(/|\\\\)", ".")
 	}
 }

--- a/src/test/groovy/com/marklogic/gradle/UnitTestTaskTest.groovy
+++ b/src/test/groovy/com/marklogic/gradle/UnitTestTaskTest.groovy
@@ -1,0 +1,28 @@
+package com.marklogic.gradle
+
+import org.junit.Test
+import com.marklogic.gradle.task.test.UnitTestTask
+
+class UnitTestTaskTest extends GroovyTestCase {
+
+
+	@Test
+	void testEscapingJavascriptFilenames() {
+		assertEquals("nestedTest.filename.sjs", UnitTestTask.escapeFilename("nestedTest/filename.sjs"))
+		assertEquals("nestedTest.filename.sjs", UnitTestTask.escapeFilename("nestedTest\\filename.sjs"))
+		assertEquals("nestedTest.doubleNestedTest.filenameWithDetails.sjs",
+			UnitTestTask.escapeFilename("nestedTest/doubleNestedTest/filenameWithDetails.sjs"))
+		assertEquals("nestedTest.doubleNestedTest.filenameWithDetails.sjs",
+			UnitTestTask.escapeFilename("nestedTest\\doubleNestedTest\\filenameWithDetails.sjs"))
+	}
+
+	@Test
+	public void testEscapingXqueryFilenames() {
+		assertEquals("nested-test.filename.xqy", UnitTestTask.escapeFilename("nested-test/filename.xqy"))
+		assertEquals("nested-test.filename.xqy", UnitTestTask.escapeFilename("nested-test\\filename.xqy"))
+		assertEquals("nested-test.double-nested-test.filename-with-details.xqy",
+			UnitTestTask.escapeFilename("nested-test/double-nested-test/filename-with-details.xqy"))
+		assertEquals("nested-test.double-nested-test.filename-with-details.xqy",
+			UnitTestTask.escapeFilename("nested-test\\double-nested-test\\filename-with-details.xqy"))
+	}
+}


### PR DESCRIPTION
Fixing https://github.com/marklogic-community/marklogic-unit-test/issues/75

Fixing a bug when writing test result XML for nested test
suites.  Originally the '/' or '\\' in the suite path would
be treated as a separate directory by Groovy, which was
throwing file not found errors as those directories did not
exist on the local file system.  Now the task will replace
directory separators with '_' when writing the XUnit XML.
