### PR TITLE
#558 Defer creating client until task is run

### DIFF
--- a/src/main/groovy/com/marklogic/gradle/task/client/CallResourceTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/client/CallResourceTask.groovy
@@ -10,7 +10,7 @@ class CallResourceTask extends MarkLogicTask {
 
 	def params = [:]
 	def method = "GET"
-	def client = newClient()
+	def client = null
 	def mimeType = "application/json"
 	String resourceName
 	String body


### PR DESCRIPTION
I built and tested this locally and it looks like it works. The `callResource` function already checks whether `client == null` and initializes it if so. 