### PR TITLE
629: Changed MLCP example project to use logback

### DIFF
--- a/examples/mlcp-project/build.gradle
+++ b/examples/mlcp-project/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath "com.marklogic:ml-gradle:4.3.6"
+		classpath "com.marklogic:ml-gradle:4.3.7-SNAPSHOT"
 	}
 }
 
@@ -29,14 +29,12 @@ configurations {
 }
 
 dependencies {
-	mlcp('com.marklogic:mlcp:10.0.9') {
-    exclude group: 'log4j', module: 'log4j'
-	}
+	mlcp 'com.marklogic:mlcp:10.0.9.5'
 
 	/**
-	 * mlcp uses Log4j for logging, and if Log4j can't find a configuration file, it will complain and you'll
-	 * get none of mlcp's usually-useful logging. It is recommended then that your Gradle configuration for
-	 * mlcp include a directory or some other resource that provides a log4j.properties file.
+	 * mlcp uses logback for logging, and without a logback configuration file, no MLCP logging will appear.
+	 * It is recommended then that your Gradle configuration for mlcp include a directory or some other resource that
+	 * provides a logback configuration file.
 	 */
 	mlcp files("lib")
 }

--- a/examples/mlcp-project/lib/log4j.properties
+++ b/examples/mlcp-project/lib/log4j.properties
@@ -1,8 +1,0 @@
-# Root logger option
-log4j.rootLogger=INFO, stdout
-
-# Direct log messages to stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/examples/mlcp-project/lib/logback.xml
+++ b/examples/mlcp-project/lib/logback.xml
@@ -1,0 +1,21 @@
+<configuration>
+
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="com.marklogic" level="INFO" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
+</configuration>
+
+  


### PR DESCRIPTION
The mlcp dependency no longer excludes anything. This will result in SLF4J warning about multiple bindings, but the logback logging will still work. Getting rid of that warning is possible, but does not seem worth the complexity in build.gradle. 