### PR TITLE
DEVEXP-183: Fixing bug in mlPrintForestPlan

### DIFF
--- a/examples/custom-forests-and-replicas-project/build.gradle
+++ b/examples/custom-forests-and-replicas-project/build.gradle
@@ -1,3 +1,3 @@
 plugins {
-	id "com.marklogic.ml-gradle" version "3.6.0"
+	id "com.marklogic.ml-gradle" version "4.5.0"
 }

--- a/src/main/groovy/com/marklogic/gradle/MarkLogicPlugin.groovy
+++ b/src/main/groovy/com/marklogic/gradle/MarkLogicPlugin.groovy
@@ -219,7 +219,8 @@ class MarkLogicPlugin implements Plugin<Project> {
 		project.task("mlDeleteForestReplicas", type: DeleteForestReplicasTask, group: forestGroup, description: "Deprecated - delete forest replicas via the command.forestNamesAndReplicaCounts map; requires -Pconfirm=true to be set so this isn't accidentally executed")
 		project.task("mlDeployCustomForests", type: DeployCustomForestsTask, group: forestGroup, description: "Deploy custom forests as defined in subdirectories of the forests configuration directory")
 		project.task("mlDeployForestReplicas", type: DeployForestReplicasTask, group: forestGroup, description: "Prefer this over mlConfigureForestReplicas; it does the same thing, but uses the ConfigureForestReplicasCommand that is used by mlDeploy")
-		project.task("mlPrintForestPlan", type: PrintForestPlanTask, group: forestGroup, description: "Print a list of primary forests to be created for a database specified by -Pdatabase=(name of database) when the database is next deployed")
+		project.task("mlPrintForestPlan", type: PrintForestPlanTask, group: forestGroup, description: "Print a list of primary forests to be created for a database specified by -Pdatabase=(name of database) when the database is next deployed. " +
+			"This is only intended to be used when forests are created dynamically via properties.")
 
 		String groupsGroup = "ml-gradle Group"
 		project.task("mlDeployGroups", type: DeployGroupsTask, group: groupsGroup, description: "Deploy each group, updating it if it exists, in the configuration directory")

--- a/src/main/groovy/com/marklogic/gradle/task/forests/PrintForestPlanTask.groovy
+++ b/src/main/groovy/com/marklogic/gradle/task/forests/PrintForestPlanTask.groovy
@@ -3,12 +3,19 @@ package com.marklogic.gradle.task.forests
 import com.marklogic.appdeployer.command.databases.DatabasePlan
 import com.marklogic.appdeployer.command.databases.DeployDatabaseCommand
 import com.marklogic.appdeployer.command.databases.DeployOtherDatabasesCommand
+import com.marklogic.appdeployer.command.forests.DeployForestsCommand
 import com.marklogic.appdeployer.impl.SimpleAppDeployer
 import com.marklogic.gradle.task.MarkLogicTask
 import com.marklogic.mgmt.api.forest.Forest
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
 
+/**
+ * This is only intended for use when creating forests via properties. The goal is to look at the properties defined by
+ * a user and preview what forests will be created based on those properties. If a user is explicitly defining forests
+ * via payloads instead of properties, the expectation is that a user can simply look at what forests already exist and
+ * compare those to the files in their project.
+ */
 class PrintForestPlanTask extends MarkLogicTask {
 
 	@TaskAction
@@ -36,16 +43,15 @@ class PrintForestPlanTask extends MarkLogicTask {
 			throw new GradleException("Did not find any database plan with a database name of: " + database)
 		}
 
-		/**
-		 * Now that we have a command, use it to build its command for deploying forests, and then use that to build
-		 * the list of forests that will be created.
-		 */
-		List<Forest> forests = deployDatabaseCommand.buildDeployForestsCommand(
-			database, getCommandContext()).buildForests(getCommandContext(), true)
-
+		DeployForestsCommand deployForestsCommand = deployDatabaseCommand.buildDeployForestsCommand(database, getCommandContext())
+		List<Forest> forests = deployForestsCommand != null ?
+			deployForestsCommand.buildForests(getCommandContext(), true) :
+			new ArrayList<>()
 
 		if (forests.isEmpty()) {
-			println "\nNo primary forests will be created the next time the database '" + database + "' is deployed; this is likely because it already has all of the primary desired forests based on the configuration settings."
+			println "\nNo primary forests will be created the next time the database '" + database + "' is deployed. This is " +
+				"likely because it already has all of the primary desired forests based on the configuration settings, or because " +
+				"you are explicitly defining forests to create instead of creating forests dynamically via properties."
 			println "\nIf replicas have been configured for the database - e.g. via mlDatabaseNamesAndReplicaCounts - and these do not exist yet, " +
 				"then replicas will be created the next time either the mlDeploy task or mlConfigureForestReplicas task is run."
 		} else {


### PR DESCRIPTION
This was not accounting for the fact that the "deployForestsCommand" will be null when a user is explicitly creating forests instead of dynamically creating them via properties. 